### PR TITLE
Add safeguards to hospital likelihood function

### DIFF
--- a/calibrate_hmpv_model.R
+++ b/calibrate_hmpv_model.R
@@ -42,13 +42,28 @@ parm_for_fit$reporting_fraction = fitted_parameters$reporting_fraction
 #parm_for_fit$baseline.txn.rate = fitted_parameters$baseline.txn.rate
 
 
+start <- c(b1 = log(0.2),
+           trans = 0.1,
+           transmission = log(8.7),
+           f = log(5e-5))
+
+lower <- c(b1 = log(0.18),
+           trans = 0,
+           transmission = log(8.5),
+           f = log(1e-7))
+
+upper <- c(b1 = log(0.22),
+           trans = 0.3,
+           transmission = log(9),
+           f = log(1e-3))
+
 fitLL <- nlminb(
-  start = c(log(0.2), 0.1, log(8.7), log(5e-5)),
+  start = start,
   objective = fit_hosp_data_fn,   # should return -logLik
   dat = my_data,
-  lower = c(log(0.18), 0, log(8.5), log(1e-7)),
-  upper = c(log(0.22), 0.3, log(9), log(1e-3)),
-  control = list(iter.max = 1000)
+  lower = lower,
+  upper = upper,
+  control = list(iter.max = 1000, trace = TRUE)
 )
 
  

--- a/fit_hosp_data_fn.R
+++ b/fit_hosp_data_fn.R
@@ -81,24 +81,38 @@ fit_hosp_data_fn <- function(parameters, dat) {
       delta3[i]*sigma3*S3[,i]*lambda1[,i]}
 
   H_true <- rowSums(H1,na.rm = T)
-  
-  
-  data_fit <- dat$hmpv 
-  
+
+
+  data_fit <- dat$hmpv
+
+  pred_counts <- H_true * parm_for_fit$reporting_fraction
+  # H_true represents modeled hospitalizations and should always be > 0.
+  # Guard against impossible non-positive or non-finite predictions.
+  if (any(!is.finite(pred_counts)) || any(pred_counts <= 0)) {
+    return(Inf)
+  }
   LLcases <- sum(dpois(x = data_fit,
-                   lambda = pmax(H_true * parm_for_fit$reporting_fraction, 1e-12),
+                   lambda = pred_counts,
                    log = T))
-  
-  
+
+
+  total_H1 <- sum(H1, na.rm = T)
+  if (!is.finite(total_H1) || total_H1 <= 0) {
+    return(Inf)
+  }
   agedist = c(sum(colSums(H1, na.rm = T)[1:12]),
               sum(colSums(H1, na.rm = T)[13:16]),
               sum(colSums(H1, na.rm = T)[17:18]),
               sum(colSums(H1, na.rm = T)[19:20]),
-              sum(colSums(H1, na.rm = T)[21])) / sum(H1, na.rm = T)
-              
+              sum(colSums(H1, na.rm = T)[21])) / total_H1
+
    agedist = c(agedist[1], agedist[2], agedist[3],
               agedist[4] + agedist[5]/8,
               7*agedist[5]/8)
+
+  if (any(!is.finite(agedist))) {
+    return(Inf)
+  }
 
   
 

--- a/fit_hosp_data_fn.R
+++ b/fit_hosp_data_fn.R
@@ -4,8 +4,10 @@ source("hmpv_transmission_model_viral_interference.R")
  
 
 fit_hosp_data_fn <- function(parameters, dat) {
-  
-  
+
+  penalty <- 1e12
+  small <- 1e-12
+
   b1 <- parameters[1] # seasonal amplitude
   trans <- parameters[2] # seasonal peak offset
   transmission <- parameters[3] # transmission parameter 
@@ -88,8 +90,8 @@ fit_hosp_data_fn <- function(parameters, dat) {
   pred_counts <- H_true * parm_for_fit$reporting_fraction
   # H_true represents modeled hospitalizations and should always be > 0.
   # Guard against impossible non-positive or non-finite predictions.
-  if (any(!is.finite(pred_counts)) || any(pred_counts <= 0)) {
-    return(Inf)
+  if (any(!is.finite(pred_counts)) || any(pred_counts <= small)) {
+    return(penalty)
   }
   LLcases <- sum(dpois(x = data_fit,
                    lambda = pred_counts,
@@ -97,8 +99,8 @@ fit_hosp_data_fn <- function(parameters, dat) {
 
 
   total_H1 <- sum(H1, na.rm = T)
-  if (!is.finite(total_H1) || total_H1 <= 0) {
-    return(Inf)
+  if (!is.finite(total_H1) || total_H1 <= small) {
+    return(penalty)
   }
   agedist = c(sum(colSums(H1, na.rm = T)[1:12]),
               sum(colSums(H1, na.rm = T)[13:16]),
@@ -111,7 +113,7 @@ fit_hosp_data_fn <- function(parameters, dat) {
               7*agedist[5]/8)
 
   if (any(!is.finite(agedist))) {
-    return(Inf)
+    return(penalty)
   }
 
   


### PR DESCRIPTION
## Summary
- guard against non-positive or non-finite predicted counts
- ensure age distribution probabilities are finite before computing likelihood

## Testing
- `Rscript -e "source('fit_hosp_data_fn.R')"` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689c9edde87c8327bf653ddf0bbc24ab